### PR TITLE
Added key propagation to CollectionMapper

### DIFF
--- a/src/CollectionMapper.php
+++ b/src/CollectionMapper.php
@@ -13,17 +13,17 @@ class CollectionMapper extends Mapper
      *
      * @return \Generator
      *
-     * @throws \Exception
+     * @throws InvalidRecordException A record in the specified collection was not an array type.
      */
     public function mapCollection(\Iterator $collection, Mapping $mapping = null, $context = null)
     {
-        foreach ($collection as $record) {
+        foreach ($collection as $key => $record) {
             if (!is_array($record)) {
-                throw new \Exception('Record must be an array.'); // TODO: Specific exception type.
+                throw new InvalidRecordException('Record must be an array.');
             }
 
-            yield $mapping
-                ? $this->mapMapping($record, $mapping, $context)
+            yield $key => $mapping
+                ? $this->mapMapping($record, $mapping, $context, $key)
                 : $record;
         }
     }

--- a/src/InvalidRecordException.php
+++ b/src/InvalidRecordException.php
@@ -1,0 +1,10 @@
+<?php
+namespace ScriptFUSION\Mapper;
+
+/**
+ * The exception that is thrown when an invalid record type is specified.
+ */
+class InvalidRecordException extends \RuntimeException
+{
+    // Intentionally empty.
+}

--- a/test/Functional/KeyPropagationTest.php
+++ b/test/Functional/KeyPropagationTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace ScriptFUSIONTest\Functional;
 
+use ScriptFUSION\Mapper\AnonymousMapping;
+use ScriptFUSION\Mapper\CollectionMapper;
 use ScriptFUSION\Mapper\Mapper;
 use ScriptFUSION\Mapper\Strategy\Collection;
 use ScriptFUSION\Mapper\Strategy\Context;
@@ -48,5 +50,18 @@ final class KeyPropagationTest extends \PHPUnit_Framework_TestCase
         );
 
         self::assertSame(['bar' => 'bar'], $mapped);
+    }
+
+    /**
+     * Tests that keys are forwarded by CollectionMapper.
+     */
+    public function testCollectionMapperPropagation()
+    {
+        $mapped = (new CollectionMapper)->mapCollection(
+            new \ArrayIterator(['foo' => ['bar']]),
+            new AnonymousMapping([new CopyKey])
+        );
+
+        self::assertSame(['foo' => ['foo']], iterator_to_array($mapped));
     }
 }

--- a/test/Integration/Mapper/CollectionMapperTest.php
+++ b/test/Integration/Mapper/CollectionMapperTest.php
@@ -3,6 +3,7 @@ namespace ScriptFUSIONTest\Integration\Mapper;
 
 use ScriptFUSION\Mapper\AnonymousMapping;
 use ScriptFUSION\Mapper\CollectionMapper;
+use ScriptFUSION\Mapper\InvalidRecordException;
 
 final class CollectionMapperTest extends \PHPUnit_Framework_TestCase
 {
@@ -12,6 +13,16 @@ final class CollectionMapperTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->mapper = new CollectionMapper;
+    }
+
+    /**
+     * Tests that when an invalid collection is specified an exception is thrown.
+     */
+    public function testMapInvalidCollection()
+    {
+        $this->setExpectedException(InvalidRecordException::class);
+
+        $this->mapper->mapCollection(new \ArrayIterator(['foo']))->valid();
     }
 
     /**
@@ -52,5 +63,18 @@ final class CollectionMapperTest extends \PHPUnit_Framework_TestCase
         $mapped = $this->mapper->mapCollection(new \ArrayIterator([[1], [2]]), new AnonymousMapping($record = ['foo']));
 
         self::assertSame([$record, $record], iterator_to_array($mapped));
+    }
+
+    /**
+     * Tests that the keys of a mapped collection are preserved.
+     */
+    public function testCollectionKeysPreserved()
+    {
+        $mapped = $this->mapper->mapCollection(
+            new \ArrayIterator($input = ['foo' => ['bar']]),
+            new AnonymousMapping(['baz'])
+        );
+
+        self::assertSame(['foo' => ['baz']], iterator_to_array($mapped));
     }
 }


### PR DESCRIPTION
This adds key propagation from the keys of collections passed to `CollectionMapper::mapCollection` to strategies invoked by the underlying `Mapper` implementation.

As a bonus, added `InvalidRecordException` thrown by `CollectionMapper`, removing outstanding *todo* notice to implement specific exception type.

### Potential BC break
`CollectionMapper::mapCollection` was changed to return collection keys verbatim instead of implicitly renumbering the output keys. This is technically a BC break but it is supposed nobody would be relying on this behaviour anyway so it should be safe to tag as a minor version.

Tests for all the above scenarios have been added.